### PR TITLE
Ignore .pmdCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ $RECYCLE.BIN/
 
 # Local environment variables
 .env
+
+# PMD cache should not be included in GitHub
+.pmdCache


### PR DESCRIPTION
There's no reason to include it in commits, as it doesn't slow down PMD much during deployments - and I think we're using the action anyway, so it would be ignored.