### PR TITLE
chore(apiVersion): Updates ApiVersion to 63.0

### DIFF
--- a/force-app/main/Universal Flow Invocable/classes/BulkCallable.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/BulkCallable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/CustomInvocable.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/CustomInvocable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/UFInvocable.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/UFInvocable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/UniversalBulkInvocable.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/UniversalBulkInvocable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/UniversalFlowInputOutput.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/UniversalFlowInputOutput.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/UniversalFlowInputOutputParameter.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/UniversalFlowInputOutputParameter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/Universal Flow Invocable/classes/UniversalInvocable.cls-meta.xml
+++ b/force-app/main/Universal Flow Invocable/classes/UniversalInvocable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Repository/BaseRepo.cls-meta.xml
+++ b/force-app/main/default/classes/Repository/BaseRepo.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/Repository/BaseRepoTests.cls-meta.xml
+++ b/force-app/main/default/classes/Repository/BaseRepoTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ULID/ULID.cls-meta.xml
+++ b/force-app/main/default/classes/ULID/ULID.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ULID/tests/ULIDTests.cls-meta.xml
+++ b/force-app/main/default/classes/ULID/tests/ULIDTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/custom metadata tools/CustomMetadataUtilDeploymentCallback.cls-meta.xml
+++ b/force-app/main/default/classes/custom metadata tools/CustomMetadataUtilDeploymentCallback.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/custom metadata tools/CustomMetadataUtilities.cls-meta.xml
+++ b/force-app/main/default/classes/custom metadata tools/CustomMetadataUtilities.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/custom metadata tools/tests/CustomMetadataUtilDeployCallbackTests.cls-meta.xml
+++ b/force-app/main/default/classes/custom metadata tools/tests/CustomMetadataUtilDeployCallbackTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/custom metadata tools/tests/CustomMetadataUtilitiesTests.cls-meta.xml
+++ b/force-app/main/default/classes/custom metadata tools/tests/CustomMetadataUtilitiesTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/FF.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/FF.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/FeatureFlag.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/FeatureFlag.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/FeatureFlagDataProvider.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/FeatureFlagDataProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/tests/FeatureFlagCommonTests.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/tests/FeatureFlagCommonTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/tests/FeatureFlagDataProviderTests.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/tests/FeatureFlagDataProviderTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/feature flags/tests/FeatureFlagTests.cls-meta.xml
+++ b/force-app/main/default/classes/feature flags/tests/FeatureFlagTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/log/Log.cls-meta.xml
+++ b/force-app/main/default/classes/log/Log.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/log/LogException.cls-meta.xml
+++ b/force-app/main/default/classes/log/LogException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/log/LogMessage.cls-meta.xml
+++ b/force-app/main/default/classes/log/LogMessage.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/log/LogTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/log/LogTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/log/tests/LogTests.cls-meta.xml
+++ b/force-app/main/default/classes/log/tests/LogTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/orgShape/CachePartitionType.cls-meta.xml
+++ b/force-app/main/default/classes/orgShape/CachePartitionType.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/orgShape/OrgShape.cls-meta.xml
+++ b/force-app/main/default/classes/orgShape/OrgShape.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/orgShape/tests/OrgShapeTests.cls-meta.xml
+++ b/force-app/main/default/classes/orgShape/tests/OrgShapeTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ouroboros/Ouroboros.cls-meta.xml
+++ b/force-app/main/default/classes/ouroboros/Ouroboros.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ouroboros/OuroborosFinalizer.cls-meta.xml
+++ b/force-app/main/default/classes/ouroboros/OuroborosFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/ouroboros/tests/OuroborosTests.cls-meta.xml
+++ b/force-app/main/default/classes/ouroboros/tests/OuroborosTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/polyfills/FailsafeExceptionHandler.cls-meta.xml
+++ b/force-app/main/default/classes/polyfills/FailsafeExceptionHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/polyfills/Polyfills.cls-meta.xml
+++ b/force-app/main/default/classes/polyfills/Polyfills.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/polyfills/tests/FailsafeExceptionHandlerTests.cls-meta.xml
+++ b/force-app/main/default/classes/polyfills/tests/FailsafeExceptionHandlerTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/polyfills/tests/PolyfillsTests.cls-meta.xml
+++ b/force-app/main/default/classes/polyfills/tests/PolyfillsTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/polyfills/tests/TestPolyfills.cls-meta.xml
+++ b/force-app/main/default/classes/polyfills/tests/TestPolyfills.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/FieldSelection.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/FieldSelection.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/Query.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/Query.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/SOQL.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/SOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/SOQLAgregate.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/SOQLAgregate.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/SOSL.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/SOSL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/tests/QueryTest.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/tests/QueryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/tests/SOQLAgregateTest.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/tests/SOQLAgregateTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/tests/SOQLTest.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/tests/SOQLTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/query lib/tests/SOSLTest.cls-meta.xml
+++ b/force-app/main/default/classes/query lib/tests/SOSLTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/EnqueueNextQueueableProcessStep.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/EnqueueNextQueueableProcessStep.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/QueueableProcess.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/QueueableProcess.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/QueueableProcessDataProvider.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/QueueableProcessDataProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/QueueableProcessMockDataProvider.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/QueueableProcessMockDataProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/tests/ExampleQueueableProcessSteps.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/tests/ExampleQueueableProcessSteps.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/queueable process/tests/QueueableProcessTests.cls-meta.xml
+++ b/force-app/main/default/classes/queueable process/tests/QueueableProcessTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/quiddity/QuiddityGuard.cls-meta.xml
+++ b/force-app/main/default/classes/quiddity/QuiddityGuard.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/quiddity/tests/QuiddityGuardTests.cls-meta.xml
+++ b/force-app/main/default/classes/quiddity/tests/QuiddityGuardTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/AsyncRestClient.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/AsyncRestClient.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/AsyncRestLibFinalizer.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/AsyncRestLibFinalizer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/HttpVerb.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/HttpVerb.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/RestClient.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/RestClient.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/RestClientLib.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/RestClientLib.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/RestLib.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/RestLib.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/RestLibApiCall.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/RestLibApiCall.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/rest lib/tests/RestLibTests.cls-meta.xml
+++ b/force-app/main/default/classes/rest lib/tests/RestLibTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/CanTheUser.cls-meta.xml
+++ b/force-app/main/default/classes/safely/CanTheUser.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/CrudType.cls-meta.xml
+++ b/force-app/main/default/classes/safely/CrudType.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/FLSType.cls-meta.xml
+++ b/force-app/main/default/classes/safely/FLSType.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/Safely.cls-meta.xml
+++ b/force-app/main/default/classes/safely/Safely.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/tests/CanTheUserTests.cls-meta.xml
+++ b/force-app/main/default/classes/safely/tests/CanTheUserTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/safely/tests/SafelyTests.cls-meta.xml
+++ b/force-app/main/default/classes/safely/tests/SafelyTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/HttpCalloutMockFactory.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/HttpCalloutMockFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/IdFactory.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/IdFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/MethodSignature.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/MethodSignature.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/MockedMethod.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/MockedMethod.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/Stub.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/Stub.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/StubUtilities.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/StubUtilities.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/test utilities/TestFactory.cls-meta.xml
+++ b/force-app/main/default/classes/test utilities/TestFactory.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/InvokeMetadataDrivenTriggerFramework.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/InvokeMetadataDrivenTriggerFramework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/MetadataTriggerFramework.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/MetadataTriggerFramework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/MetadataTriggerFrameworkException.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/MetadataTriggerFrameworkException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/MetadataTriggerFrameworkTests.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/MetadataTriggerFrameworkTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/MetadataTriggerQueryService.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/MetadataTriggerQueryService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/MetadataTriggerQueryServiceTests.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/MetadataTriggerQueryServiceTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/TriggerContext.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/TriggerContext.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/TriggerFramework.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/TriggerFramework.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/TriggerFrameworkException.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/TriggerFrameworkException.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/TriggerFrameworkLoopCount.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/TriggerFrameworkLoopCount.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/tests/SampleHandler.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/tests/SampleHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/trigger framework/tests/TriggerFrameworkTests.cls-meta.xml
+++ b/force-app/main/default/classes/trigger framework/tests/TriggerFrameworkTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Blanket update of all cls-meta.xml apiVersion tags to 63.0
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the `apiVersion` tag in various `cls-meta.xml` files from 58.0 to 63.0. This change ensures that our Salesforce classes are compatible with the latest features and improvements provided by Salesforce API version 63.0. No direct user impact is expected as this is a maintenance update.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->